### PR TITLE
Add notes about token URL to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ environment variables:
 
 ```sh
 export MICROSOFT_AUTHORIZE_URL=https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/authorize
+export MICROSOFT_TOKEN_URL=https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token
 export MICROSOFT_PROFILE_URL=...
-export MICROSOFT_TOKEN_URL=...
 ```
 
 or alternatively change your `config/runtime.exs` file to include 
@@ -180,15 +180,16 @@ your custom endpoints
 ```elixir
 config :elixir_auth_microsoft,
   #...
-  authorize_url: "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/authorize"
-  token_url: ...
+  authorize_url: "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/authorize",
+  token_url: "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token",
   profile_url: ...
 ```
 
 If you are using "Accounts in this organizational directory only 
 (Default Directory only - Single tenant)" for "Supported account types" 
 in your Azure AD application setup you must override the `MICROSOFT_AUTHORIZE_URL` 
-as shown above, or else you will get an `unauthorized_client` error.
+and `MICROSOFT_TOKEN_URL` environment variables to include your tenant ID as shown 
+above, or else you will get an `unauthorized_client` error, or an `AADSTS500202` error.
 
 
 ## 4. Add a "Sign in with Microsoft" Button to your App

--- a/azure_app_registration_guide.md
+++ b/azure_app_registration_guide.md
@@ -96,10 +96,11 @@ If you want to allow personal Hotmail/Outlook/XBox accounts,
 chose one that includes
 **personal Microsoft accounts** .
 
-Note that if you select the first option you must also provide a custom authorize URL:
+Note that if you select the first option you must also provide a custom authorize and token URLs:
 
 ```sh
 export MICROSOFT_AUTHORIZE_URL=https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/authorize
+export MICROSOFT_TOKEN_URL=https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token
 ```
 
 You can find `<your_tenant_id>` as "Directory (tenant) ID" 


### PR DESCRIPTION
My apologies, there needs to be some documentation about overriding the token URL as well.